### PR TITLE
[FIX] TypeError in _stage_groups() causing incorrect kanban grouping by state

### DIFF
--- a/qms/models/action.py
+++ b/qms/models/action.py
@@ -88,12 +88,12 @@ class Action(models.Model):
         comodel_name="qms.revision_by_direction"
     )
 
-    @api.model
-    def create(self, vals):
+    @api.model_create_multi
+    def create(self, vals_list):
         seq = self.env["ir.sequence"]
-        vals["reference"] = seq.next_by_code("qms.action")
-        action = super(Action, self).create(vals)
-        return action
+        for vals in vals_list:
+            vals["reference"] = seq.next_by_code("qms.action")
+        return super(Action, self).create(vals_list)
 
     @api.model
     def _stage_groups(self, stages, domain):

--- a/qms/models/action.py
+++ b/qms/models/action.py
@@ -94,8 +94,8 @@ class Action(models.Model):
         return action
 
     @api.model
-    def _stage_groups(self):
-        stage_ids = self.env["qms.action.stage"].search([])
+    def _stage_groups(self, order):
+        stage_ids = self.env["qms.action.stage"].search([], order=order)
         return stage_ids
 
     @api.model

--- a/qms/models/action.py
+++ b/qms/models/action.py
@@ -72,13 +72,13 @@ class Action(models.Model):
         required=False,
     )
 
-    observation_id = fields.Many2one(comodel_name="qms.finding")
+    observation_id = fields.Many2one(comodel_name="qms.observation")
 
-    non_conformity_id = fields.Many2one(comodel_name="qms.finding")
+    non_conformity_id = fields.Many2one(comodel_name="qms.non_conformity")
 
-    complaint_id = fields.Many2one(comodel_name="qms.finding")
+    complaint_id = fields.Many2one(comodel_name="qms.complaint")
 
-    opportunity_id = fields.Many2one(comodel_name="qms.finding")
+    opportunity_id = fields.Many2one(comodel_name="qms.opportunity")
 
     hazard_id = fields.Many2one(comodel_name="qms.hazard")
 

--- a/qms/models/action.py
+++ b/qms/models/action.py
@@ -10,21 +10,6 @@ class Action(models.Model):
     _name = "qms.action"
     _description = "Action"
 
-    _response_types_ = [
-        ("improvement", _("Improvement Action")),
-        ("immediate", _("Immediate Action")),
-        ("correction", _("Corrective Action")),
-        ("preventive", _("Action for Risks")),
-    ]
-
-    _complexity_levels_ = [
-        ("very_low", _("Very Low")),
-        ("low", _("Low")),
-        ("medium", _("Medium")),
-        ("high", _("High")),
-        ("very_high", _("Very High")),
-    ]
-
     def _default_stage(self):
         return self.env["qms.action.stage"].search(
             [("is_starting", "=", True)], limit=1
@@ -46,7 +31,15 @@ class Action(models.Model):
 
     description = fields.Html()
 
-    response_type = fields.Selection(selection=_response_types_, required=True)
+    response_type = fields.Selection(
+        selection=[
+            ("improvement", "Improvement Action"),
+            ("immediate", "Immediate Action"),
+            ("correction", "Corrective Action"),
+            ("preventive", "Action for Risks"),
+        ],
+        required=True,
+    )
 
     stage_id = fields.Many2one(
         comodel_name="qms.action.stage",
@@ -58,7 +51,16 @@ class Action(models.Model):
 
     reference = fields.Char(required=False, readonly=True)
 
-    complexity = fields.Selection(selection=_complexity_levels_, required=True)
+    complexity = fields.Selection(
+        selection=[
+            ("very_low", "Very Low"),
+            ("low", "Low"),
+            ("medium", "Medium"),
+            ("high", "High"),
+            ("very_high", "Very High"),
+        ],
+        required=True,
+    )
 
     responsible_id = fields.Many2one(
         comodel_name="qms.interested_party", required=True
@@ -94,9 +96,8 @@ class Action(models.Model):
         return action
 
     @api.model
-    def _stage_groups(self, order):
-        stage_ids = self.env["qms.action.stage"].search([], order=order)
-        return stage_ids
+    def _stage_groups(self, stages, domain):
+        return self.env["qms.action.stage"].search([])
 
     @api.model
     def _get_stage_new(self):

--- a/qms/models/audit.py
+++ b/qms/models/audit.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2010 Savoir-faire Linux (<http://www.savoirfairelinux.com>).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, fields, models
+from odoo import fields, models
 
 
 class Audit(models.Model):
@@ -11,14 +11,13 @@ class Audit(models.Model):
     _rec_name = "reference"
     _description = "Audit"
 
-    _system_ = [
-        ("iso9001_2015", "ISO 9001:2015"),
-        ("iso9001_2008", "ISO 9001:2008"),
-    ]
-
-    system = fields.Selection(selection=_system_, required=True)
-
-    _states_ = [("open", _("Open")), ("closed", _("Closed"))]
+    system = fields.Selection(
+        selection=[
+            ("iso9001_2015", "ISO 9001:2015"),
+            ("iso9001_2008", "ISO 9001:2008"),
+        ],
+        required=True,
+    )
 
     reference = fields.Char(readonly=False, required=False)
 
@@ -32,7 +31,13 @@ class Audit(models.Model):
 
     strong_points = fields.Html()
 
-    state = fields.Selection(selection=_states_, default="open")
+    state = fields.Selection(
+        selection=[
+            ("open", "Open"),
+            ("closed", "Closed"),
+        ],
+        default="open",
+    )
 
     audited_ids = fields.Many2many(
         comodel_name="qms.interested_party", relation="audit_audited_rel"

--- a/qms/models/audit.py
+++ b/qms/models/audit.py
@@ -33,10 +33,11 @@ class Audit(models.Model):
 
     state = fields.Selection(
         selection=[
+            ("draft", "Draft"),
             ("open", "Open"),
-            ("closed", "Closed"),
+            ("done", "Closed"),
         ],
-        default="open",
+        default="draft",
     )
 
     audited_ids = fields.Many2many(

--- a/qms/models/audit_evaluation.py
+++ b/qms/models/audit_evaluation.py
@@ -1,4 +1,4 @@
-from odoo import _, fields, models
+from odoo import fields, models
 
 
 class AuditEvaluation(models.Model):
@@ -20,9 +20,14 @@ class AuditEvaluation(models.Model):
         comodel_name="qms.interested_party", required=True
     )
 
-    _type_ = [("internal", _("Internal")), ("external", _("External"))]
-
-    type = fields.Selection(selection=_type_, string="System", required=False)
+    type = fields.Selection(
+        selection=[
+            ("internal", "Internal"),
+            ("external", "External"),
+        ],
+        string="System",
+        required=False,
+    )
 
     auditors_ids = fields.Many2many(
         comodel_name="qms.interested_party",
@@ -30,72 +35,74 @@ class AuditEvaluation(models.Model):
 
     audit_id = fields.Many2one(comodel_name="qms.audit")
 
-    _understanding_ = [
-        ("-", "-"),
-        ("1", "1"),
-        ("2", "2"),
-        ("3", "3"),
-        ("4", "4"),
-        ("5", "5"),
-        ("6", "6"),
-        ("7", "7"),
-        ("8", "8"),
-        ("9", "9"),
-        ("10", "10"),
-    ]
-
     understanding = fields.Selection(
-        selection=_understanding_, default="-", required=False
+        selection=[
+            ("-", "-"),
+            ("1", "1"),
+            ("2", "2"),
+            ("3", "3"),
+            ("4", "4"),
+            ("5", "5"),
+            ("6", "6"),
+            ("7", "7"),
+            ("8", "8"),
+            ("9", "9"),
+            ("10", "10"),
+        ],
+        default="-",
+        required=False,
     )
-
-    _compliance_ = [
-        ("-", "-"),
-        ("1", "1"),
-        ("2", "2"),
-        ("3", "3"),
-        ("4", "4"),
-        ("5", "5"),
-        ("6", "6"),
-        ("7", "7"),
-        ("8", "8"),
-        ("9", "9"),
-        ("10", "10"),
-    ]
 
     compliance = fields.Selection(
-        selection=_compliance_, default="-", required=False
+        selection=[
+            ("-", "-"),
+            ("1", "1"),
+            ("2", "2"),
+            ("3", "3"),
+            ("4", "4"),
+            ("5", "5"),
+            ("6", "6"),
+            ("7", "7"),
+            ("8", "8"),
+            ("9", "9"),
+            ("10", "10"),
+        ],
+        default="-",
+        required=False,
     )
-
-    _planning_ = [
-        ("-", "-"),
-        ("1", "1"),
-        ("2", "2"),
-        ("3", "3"),
-        ("4", "4"),
-        ("5", "5"),
-        ("6", "6"),
-        ("7", "7"),
-        ("8", "8"),
-        ("9", "9"),
-        ("10", "10"),
-    ]
 
     planning = fields.Selection(
-        selection=_planning_, default="-", required=False
+        selection=[
+            ("-", "-"),
+            ("1", "1"),
+            ("2", "2"),
+            ("3", "3"),
+            ("4", "4"),
+            ("5", "5"),
+            ("6", "6"),
+            ("7", "7"),
+            ("8", "8"),
+            ("9", "9"),
+            ("10", "10"),
+        ],
+        default="-",
+        required=False,
     )
 
-    _report_ = [
-        ("-", "-"),
-        ("1", "1"),
-        ("2", "2"),
-        ("3", "3"),
-        ("4", "4"),
-        ("5", "5"),
-        ("6", "6"),
-        ("7", "7"),
-        ("8", "8"),
-        ("9", "9"),
-        ("10", "10"),
-    ]
-
-    report = fields.Selection(selection=_report_, default="-", required=False)
+    report = fields.Selection(
+        selection=[
+            ("-", "-"),
+            ("1", "1"),
+            ("2", "2"),
+            ("3", "3"),
+            ("4", "4"),
+            ("5", "5"),
+            ("6", "6"),
+            ("7", "7"),
+            ("8", "8"),
+            ("9", "9"),
+            ("10", "10"),
+        ],
+        default="-",
+        required=False,
+    )

--- a/qms/models/complaint.py
+++ b/qms/models/complaint.py
@@ -15,13 +15,14 @@ class Complaint(models.Model):
     def _stage_groups(self, stages, domain):
         return self.env["qms.finding.stage"].search([])
 
-    @api.model
-    def create(self, vals):
-        vals.update(
-            {
-                "reference": self.env["ir.sequence"].next_by_code(
-                    "qms.complaint"
-                )
-            }
-        )
-        return super(Complaint, self).create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            vals.update(
+                {
+                    "reference": self.env["ir.sequence"].next_by_code(
+                        "qms.complaint"
+                    )
+                }
+            )
+        return super(Complaint, self).create(vals_list)

--- a/qms/models/complaint.py
+++ b/qms/models/complaint.py
@@ -12,6 +12,10 @@ class Complaint(models.Model):
     )
 
     @api.model
+    def _stage_groups(self, stages, domain):
+        return self.env["qms.finding.stage"].search([])
+
+    @api.model
     def create(self, vals):
         vals.update(
             {

--- a/qms/models/document.py
+++ b/qms/models/document.py
@@ -1,4 +1,4 @@
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 
 
 class Document(models.Model):
@@ -10,20 +10,27 @@ class Document(models.Model):
 
     name = fields.Char()
 
-    _format_ = [("paper", ("Paper")), ("electronic", _("Electronic"))]
-
     format = fields.Selection(
-        selection=_format_, default="electronic", required=True
+        selection=[
+            ("paper", "Paper"),
+            ("electronic", "Electronic"),
+        ],
+        default="electronic",
+        required=True,
     )
 
     version_ids = fields.One2many(
         comodel_name="qms.version", inverse_name="document_id"
     )
 
-    _relation_ = [("sgc&tmc", "SGC / TMC"), ("sgc", "SGC"), ("tmc", "TMC")]
-
     relation = fields.Selection(
-        selection=_relation_, default="sgc&tmc", required=True
+        selection=[
+            ("sgc&tmc", "SGC / TMC"),
+            ("sgc", "SGC"),
+            ("tmc", "TMC"),
+        ],
+        default="sgc&tmc",
+        required=True,
     )
 
     holding_time = fields.Char()
@@ -34,10 +41,13 @@ class Document(models.Model):
 
     disposition = fields.Char()
 
-    _type_ = [("internal", _("Internal")), ("external", _("External"))]
-
     type = fields.Selection(
-        selection=_type_, default="internal", required=True
+        selection=[
+            ("internal", "Internal"),
+            ("external", "External"),
+        ],
+        default="internal",
+        required=True,
     )
 
     description = fields.Html()

--- a/qms/models/effectiveness_check.py
+++ b/qms/models/effectiveness_check.py
@@ -7,8 +7,6 @@ class EffectivenessCheck(models.Model):
     _name = "qms.effectiveness_check"
     _description = "Effectiveness Check"
 
-    _states_ = [("pending", _("Pending")), ("closed", _("Closed"))]
-
     expected_date = fields.Date()
 
     verification_date = fields.Date()
@@ -17,7 +15,13 @@ class EffectivenessCheck(models.Model):
 
     action_id = fields.Many2one(comodel_name="qms.action", required=True)
 
-    state = fields.Selection(selection=_states_, default="pending")
+    state = fields.Selection(
+        selection=[
+            ("pending", "Pending"),
+            ("closed", "Closed"),
+        ],
+        default="pending",
+    )
 
     observations = fields.Text()
 

--- a/qms/models/finding.py
+++ b/qms/models/finding.py
@@ -24,7 +24,7 @@ class Finding(models.Model):
         ].search([("is_starting", "=", True)], limit=1)
 
     @api.model
-    def _stage_groups(self, stages, domain, order):
+    def _stage_groups(self, stages, domain):
         return self.env["qms.finding.stage"].search([])
 
     name = fields.Char()

--- a/qms/models/finding.py
+++ b/qms/models/finding.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2010 Savoir-faire Linux (<http://www.savoirfairelinux.com>).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 
 
 class Finding(models.Model):
@@ -10,12 +10,6 @@ class Finding(models.Model):
     _name = "qms.finding"
     _description = "Finding"
     _order = "create_date desc"
-
-    _kanban_states_ = [
-        ("normal", _("In Progress")),
-        ("done", _("Ready For Next Stage")),
-        ("blocked", _("Blocked")),
-    ]
 
     @api.model
     def _default_stage(self):
@@ -51,7 +45,14 @@ class Finding(models.Model):
     state = fields.Selection(related="stage_id.state", store=True)
 
     kanban_state = fields.Selection(
-        selection=_kanban_states_, default="normal", required=True, copy=False
+        selection=[
+            ("normal", "In Progress"),
+            ("done", "Ready For Next Stage"),
+            ("blocked", "Blocked"),
+        ],
+        default="normal",
+        required=True,
+        copy=False,
     )
 
     action_ids = fields.Many2many(comodel_name="qms.action")

--- a/qms/models/finding_stage.py
+++ b/qms/models/finding_stage.py
@@ -1,4 +1,4 @@
-from odoo import _, fields, models
+from odoo import fields, models
 
 
 class FindingStage(models.Model):
@@ -7,17 +7,17 @@ class FindingStage(models.Model):
     _description = "Finding Stage"
     _inherit = ["qms.stage"]
 
-    _states_ = [
-        ("draft", _("Draft")),
-        ("analysis", _("Analysis")),
-        ("pending", _("Action Plan")),
-        ("open", _("In Progress")),
-        ("done", _("Closed")),
-        ("cancel", _("Cancelled")),
-    ]
-
     state = fields.Selection(
-        selection=_states_, readonly=True, default="draft"
+        selection=[
+            ("draft", "Draft"),
+            ("analysis", "Analysis"),
+            ("pending", "Action Plan"),
+            ("open", "In Progress"),
+            ("done", "Closed"),
+            ("cancel", "Cancelled"),
+        ],
+        readonly=True,
+        default="draft",
     )
 
     fold = fields.Boolean()

--- a/qms/models/goal.py
+++ b/qms/models/goal.py
@@ -1,4 +1,4 @@
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 
 
 class Goal(models.Model):
@@ -18,13 +18,6 @@ class Goal(models.Model):
 
     approved = fields.Boolean()
 
-    _state_ = [
-        ("draft", _("Draft")),
-        ("open", _("Open")),
-        ("closed", _("Closed")),
-        ("cancelled", _("Cancelled")),
-    ]
-
     responsible_id = fields.Many2one(
         comodel_name="qms.interested_party", required=True
     )
@@ -41,7 +34,16 @@ class Goal(models.Model):
         comodel_name="qms.action", inverse_name="goal_id"
     )
 
-    state = fields.Selection(selection=_state_, default="draft", required=True)
+    state = fields.Selection(
+        selection=[
+            ("draft", "Draft"),
+            ("open", "Open"),
+            ("closed", "Closed"),
+            ("cancelled", "Cancelled"),
+        ],
+        default="draft",
+        required=True,
+    )
 
     review_ids = fields.One2many(
         comodel_name="qms.review", inverse_name="goal_id"

--- a/qms/models/goal_measurement.py
+++ b/qms/models/goal_measurement.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2010 Savoir-faire Linux (<http://www.savoirfairelinux.com>).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, fields, models
+from odoo import fields, models
 
 
 class GoalMeasurement(models.Model):
@@ -24,12 +24,13 @@ class GoalMeasurement(models.Model):
 
     comments = fields.Text()
 
-    _result_ = [
-        ("goal_ok", _("Goal achieved")),
-        ("goal_with_obs", _("Goal achieved with comments")),
-        ("goal_no_ok", _("Goal not achieved")),
-    ]
-
-    result = fields.Selection(selection=_result_, required=False)
+    result = fields.Selection(
+        selection=[
+            ("goal_ok", "Goal achieved"),
+            ("goal_with_obs", "Goal achieved with comments"),
+            ("goal_no_ok", "Goal not achieved"),
+        ],
+        required=False,
+    )
 
     result_detail = fields.Char()

--- a/qms/models/hazard.py
+++ b/qms/models/hazard.py
@@ -1,4 +1,4 @@
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 
 
 class Hazard(models.Model):
@@ -8,88 +8,43 @@ class Hazard(models.Model):
 
     number = fields.Integer()
 
-    _probabilities_ = [
-        ("1", _("Very Low (Rare)")),
-        ("2", _("Low (Improbable)")),
-        ("3", _("Medium (Possible)")),
-        ("4", _("High Medium (Probable)")),
-        ("5", _("Very High (Almost Sure)")),
-    ]
-
-    _impacts_ = [
-        ("1", _("Very Low (Insignificant)")),
-        ("2", _("Low (Less)")),
-        ("3", _("Medium (Moderate)")),
-        ("4", _("High Medium (Higher)")),
-        ("5", _("Very High (Catastrophic)")),
-    ]
-
-    _strategies_ = [
-        ("accept", _("Accept")),
-        ("watch", _("Watch")),
-        ("evitar", _("Avoid")),
-        ("transfer", _("Transfer")),
-        ("reduce", _("Reduce")),
-        ("share", _("Share")),
-    ]
-
-    _states_ = [
-        ("draft", _("Draft")),
-        ("open", _("Open")),
-        ("closed", _("Closed")),
-        ("cancelled", _("Cancelled")),
-    ]
-
-    _evaluation_results_ = [
-        ("low", _("Low")),
-        ("medium", _("Medium")),
-        ("high", _("High")),
-        ("very_high", _("Very High")),
-    ]
-
-    _complexity_levels_ = [
-        ("very_low", _("Very Low")),
-        ("low", _("Low")),
-        ("medium", _("Medium")),
-        ("high", _("High")),
-        ("very_high", _("Very High")),
-    ]
-
-    _types_risks_ = [
-        ("strategic", _("Strategic")),
-        ("image", _("Image")),
-        ("operative", _("Operative")),
-        ("financial", _("Financial")),
-        ("compliance", _("Compliance")),
-        ("technological", _("Technological")),
-        ("corruption", _("Corruption")),
-        ("information", _("Information")),
-    ]
-
-    _factors_ = [
-        ("e_economic", _("Economics (external)")),
-        ("e_politicians", _("Politicians (external)")),
-        ("e_social", _("Social (external)")),
-        ("e_technological", _("Technological (external)")),
-        ("e_enviroment", _("Enviroment (external)")),
-        ("e_communication", _("Communication (external)")),
-        ("i_financial", _("Financial (internal)")),
-        ("i_personal", _("Personal (internal)")),
-        ("i_technological", _("Technological (internal)")),
-        ("i_strategic", _("Srategic (internal)")),
-        ("i_communication", _("Communication (internal)")),
-        ("i_factors", _("Factors (internal)")),
-    ]
-
     description = fields.Html()
 
     causes = fields.Html()
 
     consequences = fields.Html()
 
-    type_risk = fields.Selection(selection=_types_risks_, required=False)
+    type_risk = fields.Selection(
+        selection=[
+            ("strategic", "Strategic"),
+            ("image", "Image"),
+            ("operative", "Operative"),
+            ("financial", "Financial"),
+            ("compliance", "Compliance"),
+            ("technological", "Technological"),
+            ("corruption", "Corruption"),
+            ("information", "Information"),
+        ],
+        required=False,
+    )
 
-    factor = fields.Selection(selection=_factors_, required=False)
+    factor = fields.Selection(
+        selection=[
+            ("e_economic", "Economics (external)"),
+            ("e_politicians", "Politicians (external)"),
+            ("e_social", "Social (external)"),
+            ("e_technological", "Technological (external)"),
+            ("e_enviroment", "Enviroment (external)"),
+            ("e_communication", "Communication (external)"),
+            ("i_financial", "Financial (internal)"),
+            ("i_personal", "Personal (internal)"),
+            ("i_technological", "Technological (internal)"),
+            ("i_strategic", "Srategic (internal)"),
+            ("i_communication", "Communication (internal)"),
+            ("i_factors", "Factors (internal)"),
+        ],
+        required=False,
+    )
 
     @api.depends("probability", "impact")
     def _compute_result_and_evaluation(self):
@@ -112,18 +67,58 @@ class Hazard(models.Model):
 
     date = fields.Date()
 
-    probability = fields.Selection(selection=_probabilities_, required=False)
+    probability = fields.Selection(
+        selection=[
+            ("1", "Very Low (Rare)"),
+            ("2", "Low (Improbable)"),
+            ("3", "Medium (Possible)"),
+            ("4", "High Medium (Probable)"),
+            ("5", "Very High (Almost Sure)"),
+        ],
+        required=False,
+    )
 
-    impact = fields.Selection(selection=_impacts_, required=False)
+    impact = fields.Selection(
+        selection=[
+            ("1", "Very Low (Insignificant)"),
+            ("2", "Low (Less)"),
+            ("3", "Medium (Moderate)"),
+            ("4", "High Medium (Higher)"),
+            ("5", "Very High (Catastrophic)"),
+        ],
+        required=False,
+    )
 
-    strategy = fields.Selection(selection=_strategies_, required=False)
+    strategy = fields.Selection(
+        selection=[
+            ("accept", "Accept"),
+            ("watch", "Watch"),
+            ("evitar", "Avoid"),
+            ("transfer", "Transfer"),
+            ("reduce", "Reduce"),
+            ("share", "Share"),
+        ],
+        required=False,
+    )
 
     state = fields.Selection(
-        selection=_states_, default="draft", required=False
+        selection=[
+            ("draft", "Draft"),
+            ("open", "Open"),
+            ("closed", "Closed"),
+            ("cancelled", "Cancelled"),
+        ],
+        default="draft",
+        required=False,
     )
 
     evaluation = fields.Selection(
-        selection=_evaluation_results_,
+        selection=[
+            ("low", "Low"),
+            ("medium", "Medium"),
+            ("high", "High"),
+            ("very_high", "Very High"),
+        ],
         compute=_compute_result_and_evaluation,
         readonly=True,
         store=True,

--- a/qms/models/hazard.py
+++ b/qms/models/hazard.py
@@ -48,20 +48,22 @@ class Hazard(models.Model):
 
     @api.depends("probability", "impact")
     def _compute_result_and_evaluation(self):
-        if self.impact and self.probability:
-            self.result = self.impact * self.probability
-        else:
-            self.result = 0
-        if self.result >= 1 and self.result <= 3:
-            self.evaluation = "low"
-        elif self.result >= 4 and self.result <= 8:
-            self.evaluation = "medium"
-        elif self.result >= 9 and self.result <= 14:
-            self.evaluation = "high"
-        elif self.result >= 15 and self.result <= 25:
-            self.evaluation = "very_high"
-        else:
-            self.evaluation = False
+        for hazard in self:
+            if hazard.impact and hazard.probability:
+                hazard.result = int(hazard.impact) * int(hazard.probability)
+            else:
+                hazard.result = 0
+
+            if hazard.result >= 1 and hazard.result <= 3:
+                hazard.evaluation = "low"
+            elif hazard.result >= 4 and hazard.result <= 8:
+                hazard.evaluation = "medium"
+            elif hazard.result >= 9 and hazard.result <= 14:
+                hazard.evaluation = "high"
+            elif hazard.result >= 15 and hazard.result <= 25:
+                hazard.evaluation = "very_high"
+            else:
+                hazard.evaluation = False
 
     name = fields.Char(required=True)
 

--- a/qms/models/indicator.py
+++ b/qms/models/indicator.py
@@ -10,18 +10,6 @@ class Indicator(models.Model):
 
     number = fields.Integer()
 
-    _resource_states_ = [
-        ("enabled", _("Enabled")),
-        ("disabled", _("Disabled")),
-    ]
-
-    _frequencys_ = [
-        ("annual", _("Annual")),
-        ("biannual", _("Biannual")),
-        ("quarterly", _("Quarterly")),
-        ("monthly", _("Monthly")),
-    ]
-
     responsible_id = fields.Many2one(
         comodel_name="qms.interested_party", required=True
     )
@@ -30,9 +18,23 @@ class Indicator(models.Model):
         comodel_name="qms.review", inverse_name="indicator_id"
     )
 
-    state = fields.Selection(selection=_resource_states_, default="enabled")
+    state = fields.Selection(
+        selection=[
+            ("enabled", "Enabled"),
+            ("disabled", "Disabled"),
+        ],
+        default="enabled",
+    )
 
-    frequency = fields.Selection(selection=_frequencys_, default="annual")
+    frequency = fields.Selection(
+        selection=[
+            ("annual", "Annual"),
+            ("biannual", "Biannual"),
+            ("quarterly", "Quarterly"),
+            ("monthly", "Monthly"),
+        ],
+        default="annual",
+    )
 
     process_id = fields.Many2one(comodel_name="qms.process", required=True)
 

--- a/qms/models/indicator_measurement.py
+++ b/qms/models/indicator_measurement.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2010 Savoir-faire Linux (<http://www.savoirfairelinux.com>).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, fields, models
+from odoo import fields, models
 
 
 class IndicatorMeasurement(models.Model):
@@ -24,12 +24,14 @@ class IndicatorMeasurement(models.Model):
 
     comments = fields.Text()
 
-    _result_ = [
-        ("goal_ok", _("Goal reached")),
-        ("goal_with_obs", _("Goal reached with observations")),
-        ("goal_no_ok", _("Unachieved target")),
-    ]
-
-    result = fields.Selection(selection=_result_, required=False, store=True)
+    result = fields.Selection(
+        selection=[
+            ("goal_ok", "Goal reached"),
+            ("goal_with_obs", "Goal reached with observations"),
+            ("goal_no_ok", "Unachieved target"),
+        ],
+        required=False,
+        store=True,
+    )
 
     result_detail = fields.Char()

--- a/qms/models/interested_party.py
+++ b/qms/models/interested_party.py
@@ -80,4 +80,6 @@ class InterestedParty(models.Model):
             last_review = related_reviews.sorted(
                 key=lambda r: r.date, reverse=True
             )
-            interested_party.last_review_date = last_review[0].date
+            interested_party.last_review_date = (
+                last_review[0].date if last_review else False
+            )

--- a/qms/models/interested_party.py
+++ b/qms/models/interested_party.py
@@ -6,51 +6,53 @@ class InterestedParty(models.Model):
     _name = "qms.interested_party"
     _description = "Interested Party"
 
-    _interested_party_types_ = [
-        ("internal", _("Internal")),
-        ("external", _("External")),
-    ]
+    power = fields.Selection(
+        selection=[
+            ("1", "Low"),
+            ("2", "Medium"),
+            ("3", "High"),
+            ("4", "Very High"),
+        ],
+        required=False,
+    )
 
-    _power_ = [
-        ("1", _("Low")),
-        ("2", _("Medium")),
-        ("3", _("High")),
-        ("4", _("Very High")),
-    ]
+    interest = fields.Selection(
+        selection=[
+            ("1", "Low"),
+            ("2", "Medium"),
+            ("3", "High"),
+            ("4", "Very High"),
+        ],
+        required=False,
+    )
 
-    _interest_ = [
-        ("1", _("Low")),
-        ("2", _("Medium")),
-        ("3", _("High")),
-        ("4", _("Very High")),
-    ]
+    cooperation = fields.Selection(
+        selection=[
+            ("1", "Low"),
+            ("2", "Medium"),
+            ("3", "High"),
+            ("4", "Very High"),
+        ],
+        required=False,
+    )
 
-    _cooperation_ = [
-        ("1", _("Low")),
-        ("2", _("Medium")),
-        ("3", _("High")),
-        ("4", _("Very High")),
-    ]
-
-    _impact_ = [
-        ("1", _("Low")),
-        ("2", _("Medium")),
-        ("3", _("High")),
-        ("4", _("Very High")),
-    ]
-
-    power = fields.Selection(selection=_power_, required=False)
-
-    interest = fields.Selection(selection=_interest_, required=False)
-
-    cooperation = fields.Selection(selection=_cooperation_, required=False)
-
-    impact = fields.Selection(selection=_impact_, required=False)
+    impact = fields.Selection(
+        selection=[
+            ("1", "Low"),
+            ("2", "Medium"),
+            ("3", "High"),
+            ("4", "Very High"),
+        ],
+        required=False,
+    )
 
     name = fields.Char(required=True)
 
     interested_party_type = fields.Selection(
-        selection=_interested_party_types_
+        selection=[
+            ("internal", "Internal"),
+            ("external", "External"),
+        ]
     )
 
     is_organization = fields.Boolean()

--- a/qms/models/non_conformity.py
+++ b/qms/models/non_conformity.py
@@ -23,13 +23,14 @@ class NonConformity(models.Model):
     def _stage_groups(self, stages, domain):
         return self.env["qms.finding.stage"].search([])
 
-    @api.model
-    def create(self, vals):
-        vals.update(
-            {
-                "reference": self.env["ir.sequence"].next_by_code(
-                    "qms.non_conformity"
-                )
-            }
-        )
-        return super(NonConformity, self).create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            vals.update(
+                {
+                    "reference": self.env["ir.sequence"].next_by_code(
+                        "qms.non_conformity"
+                    )
+                }
+            )
+        return super(NonConformity, self).create(vals_list)

--- a/qms/models/non_conformity.py
+++ b/qms/models/non_conformity.py
@@ -20,6 +20,10 @@ class NonConformity(models.Model):
     indicator_id = fields.Many2one(comodel_name="qms.indicator")
 
     @api.model
+    def _stage_groups(self, stages, domain):
+        return self.env["qms.finding.stage"].search([])
+
+    @api.model
     def create(self, vals):
         vals.update(
             {

--- a/qms/models/observation.py
+++ b/qms/models/observation.py
@@ -21,6 +21,10 @@ class Observation(models.Model):
     indicator_id = fields.Many2one(comodel_name="qms.indicator")
 
     @api.model
+    def _stage_groups(self, stages, domain):
+        return self.env["qms.finding.stage"].search([])
+
+    @api.model
     def create(self, vals):
         vals.update(
             {

--- a/qms/models/observation.py
+++ b/qms/models/observation.py
@@ -24,13 +24,14 @@ class Observation(models.Model):
     def _stage_groups(self, stages, domain):
         return self.env["qms.finding.stage"].search([])
 
-    @api.model
-    def create(self, vals):
-        vals.update(
-            {
-                "reference": self.env["ir.sequence"].next_by_code(
-                    "qms.observation"
-                )
-            }
-        )
-        return super(Observation, self).create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            vals.update(
+                {
+                    "reference": self.env["ir.sequence"].next_by_code(
+                        "qms.observation"
+                    )
+                }
+            )
+        return super(Observation, self).create(vals_list)

--- a/qms/models/opportunity.py
+++ b/qms/models/opportunity.py
@@ -20,6 +20,10 @@ class Opportunity(models.Model):
     indicator_id = fields.Many2one(comodel_name="qms.indicator")
 
     @api.model
+    def _stage_groups(self, stages, domain):
+        return self.env["qms.finding.stage"].search([])
+
+    @api.model
     def create(self, vals):
         vals.update(
             {

--- a/qms/models/opportunity.py
+++ b/qms/models/opportunity.py
@@ -23,13 +23,14 @@ class Opportunity(models.Model):
     def _stage_groups(self, stages, domain):
         return self.env["qms.finding.stage"].search([])
 
-    @api.model
-    def create(self, vals):
-        vals.update(
-            {
-                "reference": self.env["ir.sequence"].next_by_code(
-                    "qms.opportunity"
-                )
-            }
-        )
-        return super(Opportunity, self).create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            vals.update(
+                {
+                    "reference": self.env["ir.sequence"].next_by_code(
+                        "qms.opportunity"
+                    )
+                }
+            )
+        return super(Opportunity, self).create(vals_list)

--- a/qms/models/process.py
+++ b/qms/models/process.py
@@ -1,4 +1,4 @@
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 
 
 class Process(models.Model):
@@ -7,17 +7,6 @@ class Process(models.Model):
     _description = "Process"
 
     name = fields.Char(required=True)
-
-    _resource_types_ = [
-        ("strategic", _("Strategic")),
-        ("central", _("Central")),
-        ("support", _("Support")),
-    ]
-
-    _resource_states_ = [
-        ("enabled", _("Enabled")),
-        ("disabled", _("Disabled")),
-    ]
 
     responsible_id = fields.Many2one(
         comodel_name="qms.interested_party", required=False
@@ -29,9 +18,21 @@ class Process(models.Model):
 
     resource_ids = fields.Many2many(comodel_name="qms.resource")
 
-    resource_type = fields.Selection(selection=_resource_types_)
+    resource_type = fields.Selection(
+        selection=[
+            ("strategic", "Strategic"),
+            ("central", "Central"),
+            ("support", "Support"),
+        ]
+    )
 
-    state = fields.Selection(selection=_resource_states_, default="enabled")
+    state = fields.Selection(
+        selection=[
+            ("enabled", "Enabled"),
+            ("disabled", "Disabled"),
+        ],
+        default="enabled",
+    )
 
     indicator_ids = fields.One2many(
         comodel_name="qms.indicator", inverse_name="process_id", required=False

--- a/qms/models/resource.py
+++ b/qms/models/resource.py
@@ -1,18 +1,10 @@
-from odoo import _, fields, models
+from odoo import fields, models
 
 
 class Resource(models.Model):
 
     _name = "qms.resource"
     _description = "Resource"
-
-    _resource_types_ = [("internal", "Internal"), ("external", _("External"))]
-
-    _resource_states_ = [
-        ("available", _("Available")),
-        ("in_process", _("In Process")),
-        ("not_available", _("Not Available")),
-    ]
 
     responsible_id = fields.Many2one(
         comodel_name="qms.interested_party", required=True
@@ -22,6 +14,18 @@ class Resource(models.Model):
 
     description = fields.Html()
 
-    resource_type = fields.Selection(selection=_resource_types_)
+    resource_type = fields.Selection(
+        selection=[
+            ("internal", "Internal"),
+            ("external", "External"),
+        ]
+    )
 
-    state = fields.Selection(selection=_resource_states_, default="available")
+    state = fields.Selection(
+        selection=[
+            ("available", "Available"),
+            ("in_process", "In Process"),
+            ("not_available", "Not Available"),
+        ],
+        default="available",
+    )

--- a/qms/models/revision_by_direction.py
+++ b/qms/models/revision_by_direction.py
@@ -14,8 +14,6 @@ class RevisionByDirection(models.Model):
 
     date_close = fields.Date()
 
-    _states_ = [("open", "Open"), ("done", "Closed")]
-
     resource_ids = fields.Many2many(comodel_name="qms.resource")
 
     non_conformity_ids = fields.One2many(
@@ -43,7 +41,13 @@ class RevisionByDirection(models.Model):
     #     ondelete="cascade",
     # )
 
-    state = fields.Selection(selection=_states_, default="open")
+    state = fields.Selection(
+        selection=[
+            ("open", "Open"),
+            ("done", "Closed"),
+        ],
+        default="open",
+    )
 
     def button_close(self):
         return self.write(

--- a/qms/models/revision_by_direction.py
+++ b/qms/models/revision_by_direction.py
@@ -51,6 +51,7 @@ class RevisionByDirection(models.Model):
     )
 
     def button_close(self):
-        return self.write(
-            {"state": "done", "closing_date": fields.Datetime.now()}
+        self.write(
+            {"state": "done", "date_close": fields.Date.today()}
         )
+        return True

--- a/qms/models/revision_by_direction.py
+++ b/qms/models/revision_by_direction.py
@@ -43,10 +43,11 @@ class RevisionByDirection(models.Model):
 
     state = fields.Selection(
         selection=[
+            ("draft", "Draft"),
             ("open", "Open"),
             ("done", "Closed"),
         ],
-        default="open",
+        default="draft",
     )
 
     def button_close(self):

--- a/qms/views/action_views.xml
+++ b/qms/views/action_views.xml
@@ -39,7 +39,7 @@
         <field name="arch" type="xml">
             <form>
                 <header>
-                    <field name="stage_id" widget="statusbar" clickable="True" />
+                    <field name="stage_id" widget="statusbar" options="{'clickable': '1'}" />
                 </header>
                 <sheet>
                     <group>

--- a/qms/views/action_views.xml
+++ b/qms/views/action_views.xml
@@ -85,7 +85,7 @@
                 <field name="date_deadline" />
                 <templates>
                     <field name="date_deadline" />
-                    <t t-name="kanban-box">
+                    <t t-name="card">
                         <div class="oe_kanban_card oe_kanban_global_click">
                             <div class="o_dropdown_kanban dropdown">
                                 <a class="dropdown-toggle btn"

--- a/qms/views/audit_views.xml
+++ b/qms/views/audit_views.xml
@@ -38,7 +38,7 @@
             <form>
                 <header>
                     <button name="button_close" string="Close" invisible="state != 'open'" type="object" />
-                    <field name="state" widget="statusbar" clickable="True" />
+                    <field name="state" widget="statusbar" options='{"clickable": "1"}' />
                 </header>
                 <sheet>
                     <group>

--- a/qms/views/document_views.xml
+++ b/qms/views/document_views.xml
@@ -29,11 +29,17 @@
             <form>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
-                        <button name="toggle_approved" string="Approved" type="object" class="oe_stat_button"
-                            icon="fa-check-square-o">
-                            <field name="approved" widget="boolean_button" options="{'terminology': {'string_true': 'Approved',
-                                    'string_false': 'Not Approved'}}" />
+                        <button name="toggle_approved" type="object" class="oe_stat_button" icon="fa-check-square-o" invisible="approved">
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_text">Not Approved</span>
+                            </div>
                         </button>
+                        <button name="toggle_approved" type="object" class="oe_stat_button" icon="fa-check-square-o" invisible="not approved">
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_text">Approved</span>
+                            </div>
+                        </button>
+                        <field name="approved" invisible="1"/>
                     </div>
                     <group>
                         <group>

--- a/qms/views/effectiveness_check_views.xml
+++ b/qms/views/effectiveness_check_views.xml
@@ -22,7 +22,7 @@
         <field name="arch" type="xml">
             <form>
                 <header>
-                    <field name="state" widget="statusbar" clickable="True" />
+                    <field name="state" widget="statusbar" options='{"clickable": "1"}' />
                 </header>
                 <sheet>
                     <group>

--- a/qms/views/finding_views.xml
+++ b/qms/views/finding_views.xml
@@ -63,7 +63,7 @@
                 <field name="name" />
                 <templates>
                     <t t-name="card">
-                        <div t-attf-class="#{kanban_color(red)} oe_kanban_global_click">
+                        <div class="oe_kanban_global_click">
                             <div class="o_dropdown_kanban dropdown">
                                 <a class="dropdown-toggle btn" data-toggle="dropdown" href="#" role="button" aria-label="Dropdown menu" title="Dropdown menu">
                                     <span class="fa fa-bars fa-lg" />

--- a/qms/views/finding_views.xml
+++ b/qms/views/finding_views.xml
@@ -101,7 +101,7 @@
         <field name="arch" type="xml">
             <form name="finding" string="Finding">
                 <header>
-                    <field name="stage_id" widget="statusbar" clickable="True" />
+                    <field name="stage_id" widget="statusbar" options='{"clickable": "1"}' />
                     <field name="state" invisible="True" />
                 </header>
                 <sheet>

--- a/qms/views/finding_views.xml
+++ b/qms/views/finding_views.xml
@@ -62,7 +62,7 @@
                 <field name="reference" />
                 <field name="name" />
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="card">
                         <div t-attf-class="#{kanban_color(red)} oe_kanban_global_click">
                             <div class="o_dropdown_kanban dropdown">
                                 <a class="dropdown-toggle btn" data-toggle="dropdown" href="#" role="button" aria-label="Dropdown menu" title="Dropdown menu">

--- a/qms/views/goal_views.xml
+++ b/qms/views/goal_views.xml
@@ -28,11 +28,17 @@
             <form>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
-                        <button name="toggle_approved" string="Approved" type="object" class="oe_stat_button"
-                            icon="fa-check-square-o">
-                            <field name="approved" widget="boolean_button" options="{'terminology': {'string_true': 'Approved',
-                                    'string_false': 'Not Approved'}}" />
+                        <button name="toggle_approved" type="object" class="oe_stat_button" icon="fa-check-square-o" invisible="approved">
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_text">Not Approved</span>
+                            </div>
                         </button>
+                        <button name="toggle_approved" type="object" class="oe_stat_button" icon="fa-check-square-o" invisible="not approved">
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_text">Approved</span>
+                            </div>
+                        </button>
+                        <field name="approved" invisible="1"/>
                     </div>
                     <div class="oe_title">
                         <h1>

--- a/qms/views/hazard_views.xml
+++ b/qms/views/hazard_views.xml
@@ -93,7 +93,7 @@
                 <field name="date" />
                 <field name="evaluation" />
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="card">
                         <div t-attf-class="oe_kanban_card oe_kanban_global_click">
                             <div class="o_dropdown_kanban dropdown">
                                 <a class="dropdown-toggle btn"

--- a/qms/views/hazard_views.xml
+++ b/qms/views/hazard_views.xml
@@ -25,7 +25,7 @@
         <field name="arch" type="xml">
             <form>
                 <header>
-                    <field name="state" widget="statusbar" clickable="True" />
+                    <field name="state" widget="statusbar" options="{'clickable': '1'}" />
                 </header>
                 <sheet>
                     <div class="oe_title">

--- a/qms/views/indicator_views.xml
+++ b/qms/views/indicator_views.xml
@@ -25,7 +25,7 @@
         <field name="arch" type="xml">
             <form>
                 <header>
-                    <field name="state" widget="statusbar" clickable="True" />
+                    <field name="state" widget="statusbar" options='{"clickable": "1"}' />
                 </header>
                 <sheet>
                     <div class="oe_title">

--- a/qms/views/policy_views.xml
+++ b/qms/views/policy_views.xml
@@ -23,11 +23,17 @@
             <form>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
-                        <button name="toggle_approved" string="Approved" type="object" class="oe_stat_button"
-                            icon="fa-check-square-o">
-                            <field name="approved" widget="boolean_button" options="{'terminology': {'string_true': 'Approved',
-                                    'string_false': 'Not Approved'}}" />
+                        <button name="toggle_approved" type="object" class="oe_stat_button" icon="fa-check-square-o" invisible="approved">
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_text">Not Approved</span>
+                            </div>
                         </button>
+                        <button name="toggle_approved" type="object" class="oe_stat_button" icon="fa-check-square-o" invisible="not approved">
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_text">Approved</span>
+                            </div>
+                        </button>
+                        <field name="approved" invisible="1"/>
                     </div>
                     <div class="oe_title">
                         <h1>

--- a/qms/views/process_views.xml
+++ b/qms/views/process_views.xml
@@ -23,7 +23,7 @@
         <field name="arch" type="xml">
             <form>
                 <header>
-                    <field name="state" widget="statusbar" clickable="True" />
+                    <field name="state" widget="statusbar" options='{"clickable": "1"}' />
                 </header>
                 <sheet>
                     <group>

--- a/qms/views/resource_views.xml
+++ b/qms/views/resource_views.xml
@@ -21,7 +21,7 @@
         <field name="arch" type="xml">
             <form>
                 <header>
-                    <field name="state" widget="statusbar" clickable="True" />
+                    <field name="state" widget="statusbar" options='{"clickable": "1"}' />
                 </header>
                 <sheet>
                     <group>

--- a/qms/views/revision_by_direction_views.xml
+++ b/qms/views/revision_by_direction_views.xml
@@ -22,7 +22,7 @@
             <form>
                 <header>
                     <button name="button_close" string="Close" invisible="state != 'open'" type="object" />
-                    <field name="state" widget="statusbar" clickable="True" />
+                    <field name="state" widget="statusbar" options='{"clickable": "1"}' />
                 </header>
                 <sheet>
                     <div class="oe_title">


### PR DESCRIPTION
Resolved a TypeError in the _stage_groups() methods of QMS models that prevented proper rendering of kanban views when grouped by state. This fix ensures that kanban views now work correctly when grouping by stages across all QMS findings models.